### PR TITLE
chore: align repo with migrate-content-to-zbb skill + migrate 3 suites

### DIFF
--- a/.claude/skills/migrate-packages/SKILL.md
+++ b/.claude/skills/migrate-packages/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: migrate-packages
+description: Migrate the next batch of suites to the gradle pipeline. Drops per-suite build.gradle.kts marker, ensures .npmrc, runs ./gradlew :<vendor>:<suite>:gate, fixes drift, major-bumps the version (1.x → 2.0.0), commits per-suite.
+argument-hint: "[<vendor>/<suite>...] [--batch=N] [--dry-run]"
+---
+
+# Migrate Suite Packages
+
+Per-repo companion to `/migrate-content-to-zbb` (which bootstrapped this repo onto gradle). Use this skill to migrate suites **one at a time** within `org/suite`. Layout: `package/<vendor>/<suite>/` (depth 2).
+
+## Trigger
+
+```
+/migrate-packages [<vendor>/<suite>...] [--batch=N] [--dry-run]
+```
+
+Examples:
+- `/migrate-packages` — pick the next N pending suites from `MIGRATION_STATUS.md` (or `find` if no tracker).
+- `/migrate-packages aicpa/soc2 atlassian/cloud iso/27001` — migrate exactly these.
+- `/migrate-packages --batch=5 --dry-run` — show the next 5 candidates without changing anything.
+
+## Pre-flight
+
+1. `git status` — must be on a feature branch, not `main`.
+2. Confirm gradle bootstrap is in place: root `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `gradle-ci.properties` exist; `.github/workflows/publish.yml` uses `zbb-publish-reusable.yml`. If anything is missing, abort and direct the user to `/migrate-content-to-zbb`.
+3. Identify candidates: directories matching `package/<vendor>/<suite>/` WITHOUT a `build.gradle.kts` marker. Check `MIGRATION_STATUS.md` for pending vs flagged.
+4. Order: simplest first (smallest `index.yml`, no logo edge cases). Skip anything in `MIGRATION_STATUS.md`'s `Flagged` section — fix that drift in a separate commit before migrating.
+5. Confirm the **parent vendor exists** in `org/vendor` and is on the gradle line. Suites depend on a vendor row at load time; if the vendor isn't published, the dataloader gate will fail with a vendor-lookup error.
+
+## Per-suite loop
+
+For each suite in the batch, do steps 1–6 in order, then commit and move on.
+
+### 1. Drop the marker
+Create `package/<vendor>/<suite>/build.gradle.kts`:
+```kotlin
+plugins { id("zb.content") }
+```
+
+### 2. Ensure `.npmrc`
+The validator requires `package/<vendor>/<suite>/.npmrc`. If absent, copy from a sibling already-migrated suite (e.g. `package/adobe/ccf/.npmrc`).
+
+### 3. Run gate first (no version bump yet)
+```bash
+./gradlew :<vendor>:<suite>:gate
+```
+The validator surfaces drift one error at a time. Common fixes for suites:
+
+- **`package.json name`** must equal `@zerobias-org/suite-<vendor>-<suite>` (matching the path segments). Fix the `name` to match the directory; do NOT rename the directory.
+- **`zerobias.package`** must equal `<vendor>.<suite>` (dot-separated). Legacy `auditmation.package` is accepted but should be renamed.
+- **`vendorId` mismatch** — the dataloader looks up the parent vendor by id and rejects if `vendor.code != index.yml.vendorCode`. Run `npm install` in the suite dir, then copy the parent vendor's `id` from `node_modules/@zerobias-org/vendor-<vendorCode>/index.yml` into `index.yml.vendorId`.
+- **Missing `.npmrc`** — see step 2.
+- **Logo issues**:
+  - Multiple logo files (`logo.svg` + `logo.png`) — keep one.
+  - Magic-byte mismatch (e.g. `logo.svg` is actually an HTML S3 error page) — re-fetch the original or remove.
+  - Size out of range (<500B / >5MB) — replace.
+  - `package.json` `files` array doesn't include the logo — add `"logo.*"` (or the exact filename).
+  - Suites without a logo are valid (logos are optional in this validator) — early-return path; no action needed.
+- **Duplicate `id` UUID** (`:validateUniqueIds` collision) — investigate which other suite owns that UUID. The newcomer needs a fresh UUID via `uuidgen`. Existing UUIDs are stable — don't change them.
+- **Template placeholder leftovers** (`{vendor}`, `${vendor}`, `{code}` still in any field) — replace with the actual values. The validator will catch most via `requireNonBlankString`'s placeholder check.
+
+Re-run `:gate` after each fix until it passes.
+
+### 4. Major-bump version
+```bash
+# package/<vendor>/<suite>/package.json: bump major.
+# 1.x.x → 2.0.0    (most existing suites)
+# 0.x.x → 1.0.0    (rare)
+# 2.x.x — no-op    (already on the gradle line)
+```
+Universal repo rule: every suite's first gradle publish gets a major bump. This is the version-line transition, not a content change.
+
+### 5. (Optional) Re-run `:gate` after the version bump
+Cheap sanity check.
+
+### 6. Commit
+One commit per suite. Conventional commit format:
+```
+feat(suite-<vendor>-<suite>)!: migrate to gradle pipeline (<oldVer> → 2.0.0)
+```
+The `!` marks the major bump as breaking. Stage exactly: `package/<vendor>/<suite>/build.gradle.kts`, `package/<vendor>/<suite>/.npmrc` (if you added it), `package/<vendor>/<suite>/package.json` (version bump), and any drift fixes (e.g. `index.yml`, `logo.svg`).
+
+### 7. (After the batch) Verify on a feature branch
+```bash
+gh workflow run publish.yml --ref <branch>
+```
+On a feature branch, `version` (single-writer) is skipped and `publish` runs in pre-release mode (no `latest` dist-tag). Confirm `detect` lists exactly the suites you bumped, then validate the published artifacts before merging to main.
+
+## Picking the next batch
+
+Order rules of thumb:
+1. Skip the `MIGRATION_STATUS.md` `Flagged` section until its drift is fixed in a separate PR.
+2. Group suites by parent vendor when possible — failure modes (stale `vendorId`, drifted vendor reference) are shared.
+3. Start with simple, single-version frameworks (`adobe/ccf`, `aicpa/gapp`) before tackling multi-region offerings (`amazon/aws`, `microsoft/azure`).
+4. Cap each PR at ~10 suites. Easier to review, easier to bisect.
+5. Run `./scripts/migration-status.sh` after each batch to refresh the tracker.
+
+## What NOT to do
+
+- Do NOT change suite `id` UUIDs. Stable identifiers; changing one detaches existing DB rows.
+- Do NOT change `vendorId` to "fix" a mismatch — fix the `vendorCode` in your suite or update the parent vendor's `index.yml`. Whichever side is wrong.
+- Do NOT rename directories to make `package.json name` match. Metadata follows the directory.
+- Do NOT skip the major bump because "no source changed". The bump reflects the publish-pipeline transition.
+- Do NOT batch unrelated suites into one commit. One commit per suite keeps `git revert` precise.
+- Do NOT touch `.husky/` if present — empty placeholder, not part of canonical pattern.
+
+## Reference files
+
+- `package/adobe/ccf/`, `package/amazon/aws/`, `package/avigilon/alta/`, `package/google/gcp/`, `package/google/workspace/` — already migrated; use as drop-in references.
+- `templates/index.yml`, `templates/package.json` — what a NEW suite looks like (single-curly placeholders: `{vendor}`, `{code}`, `{name}`).
+- `MIGRATION_STATUS.md` — pending / done / flagged tracker. Regenerate via `./scripts/migration-status.sh`.
+- Root `build.gradle.kts:9-37` — validator philosophy comment.
+- `org/vendor/` — parent dependency repo. Suites' `vendorId` must point to a vendor `id` from there.
+- `org/util/packages/build-tools/.../SchemaPrimitives.kt` — validator helpers and error message shapes.
+
+## See also
+
+- `/migrate-content-to-zbb` — meta-repo skill that bootstrapped this repo. Use only when migrating a new repo onto gradle, not for per-suite work here.
+- `.claude/skills/create-suite.md` — sibling skill for creating a NEW suite from a ZeroBias task. Different workflow.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish Suite
 
 on:
   push:
@@ -12,178 +12,17 @@ on:
         description: 'Suite to publish (e.g. adobe/ccf). Leave blank for all changed.'
         required: false
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  ZB_TOKEN: ${{ secrets.ZB_TOKEN }}
-  NEON_PARENT_BRANCH: content-master
-  NEON_DB_ROLE: neondb_owner
-  NEON_DB_NAME: zerobias
-  CI: true
-
 permissions:
   contents: write
   packages: write
   id-token: write
 
 jobs:
-  detect:
-    runs-on: ubuntu-latest
-    outputs:
-      suites: ${{ steps.changed.outputs.suites }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect changed suites
-        id: changed
-        run: |
-          if [ -n "${{ inputs.suite }}" ]; then
-            echo "suites=[\"${{ inputs.suite }}\"]" >> $GITHUB_OUTPUT
-            echo "Manual dispatch: ${{ inputs.suite }}"
-            exit 0
-          fi
-
-          BRANCH="${GITHUB_REF#refs/heads/}"
-
-          if [ "$BRANCH" = "main" ]; then
-            BASE_REF=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -z "$BASE_REF" ]; then
-              echo "No tags found — publishing all gradle-migrated suites"
-              SUITES=$(find package -mindepth 3 -maxdepth 3 -name "build.gradle.kts" | \
-                sed 's|^package/||; s|/build.gradle.kts||' | \
-                jq -R -s -c 'split("\n") | map(select(length > 0))')
-              echo "suites=$SUITES" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          else
-            BASE_REF="origin/main"
-          fi
-
-          echo "Comparing against: $BASE_REF"
-
-          # For each changed file under package/, walk up to find build.gradle.kts.
-          # Suites live at package/<vendor>/<suite>/build.gradle.kts.
-          SUITES="[]"
-          for file in $(git diff --name-only "$BASE_REF" HEAD -- 'package/'); do
-            dir="$file"
-            while [ "$dir" != "package" ] && [ "$dir" != "." ]; do
-              dir=$(dirname "$dir")
-              if [ -f "$dir/build.gradle.kts" ]; then
-                s=$(echo "$dir" | sed 's|^package/||')
-                SUITES=$(echo "$SUITES" | jq -c "if index(\"$s\") then . else . + [\"$s\"] end")
-                break
-              fi
-            done
-          done
-
-          echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "Changed suites: $SUITES"
-
   publish:
-    needs: detect
-    if: needs.detect.outputs.suites != '[]'
-    runs-on: ubuntu-latest
-    env:
-      ZB_SLOT: ci-${{ github.run_id }}-${{ github.run_attempt }}
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: ${{ fromJson(needs.detect.outputs.suites) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Authenticate to Vault
-        id: vault
-        uses: hashicorp/vault-action@v3
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: publishing-role
-          path: gh-actions
-          secrets: |
-            operations-kv/data/ci/github writePackagesToken | NPM_TOKEN;
-            operations-kv/data/ci/github readPackagesToken | READ_TOKEN;
-            operations-kv/data/neon/content api-key | NEON_API_KEY;
-            operations-kv/data/neon/content project-id | NEON_PROJECT_ID;
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://npm.pkg.github.com'
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Configure git user
-        run: |
-          git config --global user.email "ci@neverfail.com"
-          git config --global user.name "@$GITHUB_ACTOR"
-
-      - name: Install global tools
-        run: |
-          cp .npmrc $HOME/.npmrc
-          cp .npmrc $NPM_CONFIG_USERCONFIG
-          npm i -g @zerobias-org/zbb
-          npm i -g @zerobias-com/platform-dataloader
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
-
-      - name: Bootstrap zbb slot
-        run: |
-          zbb slot create $ZB_SLOT --ephemeral
-          zbb stack add .
-        env:
-          CI: 'true'
-
-      - name: Publish ${{ matrix.suite }}
-        run: |
-          cd package/${{ matrix.suite }}
-          zbb publish
-
-      - name: Generate packages file
-        if: success()
-        run: |
-          cd package/${{ matrix.suite }}
-          VERSION=$(node -p "require('./package.json').version")
-          NAME=$(node -p "require('./package.json').name")
-          echo "[{\"name\":\"$NAME\",\"version\":\"$VERSION\",\"location\":\"$(pwd)\"}]" > /tmp/published-packages.json
-
-      - name: Release Announcement
-        if: success()
-        uses: zerobias-org/devops/nx-actions/release-announcement@main
-        with:
-          packages-file: /tmp/published-packages.json
-          branch: ${{ github.ref_name }}
-          dist-tag: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'dev' && 'dev' || 'uat' }}
-        env:
-          SLACK_RELEASES_WEBHOOK: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
-          SLACK_DEVOPS_NOTIFICATIONS: ${{ secrets.SLACK_DEVOPS_NOTIFICATIONS }}
-          READ_TOKEN: ${{ env.READ_TOKEN }}
-
-  # Sync main → uat → qa → dev after successful publish
-  sync:
-    needs: publish
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sync branches
-        uses: zerobias-org/devops/nx-actions/sync-branches@main
-        with:
-          branch: ${{ github.ref_name }}
+    uses: zerobias-org/devops/.github/workflows/zbb-publish-reusable.yml@main
+    with:
+      package-depth: 2
+      ghcr-namespace: zerobias-org
+      dispatch-input-name: suite
+      dispatch-input-value: ${{ inputs.suite }}
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ serverless.yml
 build/
 .gradle
 .zbb-monorepo/
+gradle-local.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ extra["contentValidator"] = { proj: org.gradle.api.Project ->
 
     require(projectDir.resolve("index.yml").isFile)    { "$tag index.yml missing in ${projectDir.path}" }
     require(projectDir.resolve("package.json").isFile) { "$tag package.json missing in ${projectDir.path}" }
+    require(projectDir.resolve(".npmrc").isFile)       { "$tag .npmrc missing in ${projectDir.path}" }
 
     // ── 1. Filesystem ↔ npm ↔ zerobias-block triangulation ──
     // For suites, the directory layout is package/<vendor>/<suite>/.
@@ -49,18 +50,13 @@ extra["contentValidator"] = { proj: org.gradle.api.Project ->
     // those two segments — and BOTH must agree.
     val suiteCode = projectDir.name
     val vendorCode = projectDir.parentFile.name
-    val expectedNpmName = "@zerobias-org/suite-$vendorCode-$suiteCode"
-    val expectedZerobiasPackage = "$vendorCode.$suiteCode"
-
     val pkgDoc = SchemaPrimitives.parseJson(projectDir.resolve("package.json"))
-    require(pkgDoc["name"] == expectedNpmName) {
-        "$tag package.json name='${pkgDoc["name"]}' must equal '$expectedNpmName' (derived from path package/$vendorCode/$suiteCode)"
-    }
-    val zbPackage = SchemaPrimitives.getPath(pkgDoc, "zerobias.package")
-        ?: SchemaPrimitives.getPath(pkgDoc, "auditmation.package")
-    require(zbPackage == expectedZerobiasPackage) {
-        "$tag zerobias.package='$zbPackage' must equal '$expectedZerobiasPackage' (derived from path package/$vendorCode/$suiteCode)"
-    }
+    SchemaPrimitives.requirePackageIdentity(
+        pkgDoc,
+        expectedNpmName = "@zerobias-org/suite-$vendorCode-$suiteCode",
+        expectedZerobiasPackage = "$vendorCode.$suiteCode",
+        field = "$tag package.json",
+    )
 
     // ── 2. Logo file correctness ──
     validateLogo(projectDir, pkgDoc, tag)

--- a/gradle-ci.properties
+++ b/gradle-ci.properties
@@ -1,0 +1,8 @@
+# CI properties — checked in
+# Values use {{vault.*}} references resolved at task execution time
+
+npmToken={{vault.operations-kv/ci/github.readPackagesToken}}
+writeToken={{vault.operations-kv/ci/github.writePackagesToken}}
+zbToken={{vault.operations-kv/ci/zerobias/org.zb-token}}
+dispatchToken={{vault.operations-kv/ci/github.docsDeploymentToken}}
+username={{vault.operations-kv/ci/github.username}}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,32 @@
+# Shared properties — checked in
+# Override locally via gradle-local.properties (gitignored)
+# CI overrides via gradle-ci.properties (checked in, vault refs)
+
+# Node.js
+nodeVersion=22.21.0
+
+# npm registry
+npmRegistry=https://npm.pkg.github.com/
+
+# Docker registry
+dockerRegistry=961260934100.dkr.ecr.us-east-1.amazonaws.com
+
+# Database defaults (local dev)
+pgHost=localhost
+pgPort=15432
+pgUser=postgres
+pgPassword=postgres
+pgDatabase=nfa_test
+
+# AWS
+awsRegion=us-east-1
+
+# Vault
+vaultAddr=https://vault.auditmation.io:8200
+
+# Logging
+logLevel=info
+
+# Gradle performance
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/package/aicpa/soc2/build.gradle.kts
+++ b/package/aicpa/soc2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aicpa/soc2/package.json
+++ b/package/aicpa/soc2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-aicpa-soc2",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "Suite package soc2 for vendor aicpa.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/aiuc/aiuc_1/build.gradle.kts
+++ b/package/aiuc/aiuc_1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aiuc/aiuc_1/package.json
+++ b/package/aiuc/aiuc_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-aiuc-aiuc_1",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Suite package aiuc_1 for vendor aiuc.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ar/ppl/build.gradle.kts
+++ b/package/ar/ppl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ar/ppl/package.json
+++ b/package/ar/ppl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-ar-ppl",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for ar-ppl",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zerobias-org/suite-${vendor}-{code}",
+  "name": "@zerobias-org/suite-{vendor}-{code}",
   "version": "1.0.0-rc.1",
   "description": "{name}",
   "author": "team@zerobias.com",


### PR DESCRIPTION
## Summary

- **Bootstrap alignment** — bring this repo to parity with the new `/migrate-content-to-zbb` skill checklist (validator refactor, gradle properties, reusable publish workflow, template fix, companion skill).
- **First post-alignment migration batch** — migrate `aicpa/soc2`, `aiuc/aiuc_1`, `ar/ppl` to the gradle pipeline.

## Bootstrap alignment (commit `2078d93`)

| Phase | Change |
|---|---|
| Validator | `build.gradle.kts` now uses `SchemaPrimitives.requirePackageIdentity` and requires `.npmrc` per suite (matches `org/vendor`). |
| Gradle config | New `gradle.properties` (Node 22.21.0, registries, AWS, Vault, perf flags) + `gradle-ci.properties` (vault-resolved tokens). |
| `.gitignore` | Ignores `gradle-local.properties`. |
| Publish workflow | Switched to `zerobias-org/devops/.github/workflows/zbb-publish-reusable.yml@main` (depth 2, ghcr `zerobias-org`, dispatch input `suite`). Brings single-writer version bump + `event.before` baseline diff for free. |
| Template fix | `templates/package.json` had mixed `${vendor}` / `{vendor}` placeholders — normalized to single-curly. |
| Companion skill | Installed `.claude/skills/migrate-packages/SKILL.md` — per-repo skill for migrating individual suites against the bootstrapped pipeline. |

## Suite migrations (commits `e1cdddd`, `ab588be`, `663dd0b`)

| Suite | Old | New |
|---|---|---|
| `aicpa/soc2` | 1.0.8 | 2.0.0 |
| `aiuc/aiuc_1` | 1.0.3 | 2.0.0 |
| `ar/ppl` | 1.0.3 | 2.0.0 |

Per repo convention, every suite gets a major bump on first gradle publish (lerna 1.x line → gradle 2.x line). All three already had `.npmrc`, so no per-suite copy was needed. `validateUniqueIds` reports 292 unique ids across 292 suites — no UUID collisions.

## Test plan

- [ ] CI: `Publish Suite` workflow on the branch — `detect` should list exactly the 3 migrated suites, `publish` should run pre-release for each (no `latest` dist-tag on a feature branch).
- [ ] Local: `./gradlew :aicpa:soc2:gate :aiuc:aiuc_1:gate :ar:ppl:gate` (full gate including `testIntegrationDataloader` — needs `NEON_API_KEY` + `NEON_PROJECT_ID`). The cheap `validateContent` already passes for all three.
- [ ] Verify `MIGRATION_STATUS.md` regenerates cleanly via `./scripts/migration-status.sh` (going from 5/292 to 8/292 migrated). Not part of this PR — run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)