### PR TITLE
feat: migrate 50 suites (batch 4)

### DIFF
--- a/package/at/dsg/build.gradle.kts
+++ b/package/at/dsg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/at/dsg/gate-stamp.json
+++ b/package/at/dsg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/at/dsg/package.json
+++ b/package/at/dsg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-at-dsg",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for at-dsg",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/au/cp_sitc/build.gradle.kts
+++ b/package/au/cp_sitc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/au/cp_sitc/gate-stamp.json
+++ b/package/au/cp_sitc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/au/cp_sitc/package.json
+++ b/package/au/cp_sitc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-au-cp_sitc",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for au-cp_sitc",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/au/ism/build.gradle.kts
+++ b/package/au/ism/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/au/ism/gate-stamp.json
+++ b/package/au/ism/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/au/ism/package.json
+++ b/package/au/ism/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-au-ism",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for au-ism",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/bm/bmaccc/build.gradle.kts
+++ b/package/bm/bmaccc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bm/bmaccc/gate-stamp.json
+++ b/package/bm/bmaccc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bm/bmaccc/package.json
+++ b/package/bm/bmaccc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-bm-bmaccc",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package  Bermuda Monetary Authority Cybersecurity Code of Conduct for vendor Bermuda.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/ca/pipeda/build.gradle.kts
+++ b/package/ca/pipeda/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ca/pipeda/gate-stamp.json
+++ b/package/ca/pipeda/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ca/pipeda/package.json
+++ b/package/ca/pipeda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-ca-pipeda",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for ca-pipeda",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cisa/ssdaf/build.gradle.kts
+++ b/package/cisa/ssdaf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cisa/ssdaf/gate-stamp.json
+++ b/package/cisa/ssdaf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cisa/ssdaf/package.json
+++ b/package/cisa/ssdaf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-cisa-ssdaf",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for cisa-ssdaf",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cn/pipl/build.gradle.kts
+++ b/package/cn/pipl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cn/pipl/gate-stamp.json
+++ b/package/cn/pipl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cn/pipl/package.json
+++ b/package/cn/pipl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-cn-pipl",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for cn-pipl",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/csa/ccm/build.gradle.kts
+++ b/package/csa/ccm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/csa/ccm/gate-stamp.json
+++ b/package/csa/ccm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/csa/ccm/package.json
+++ b/package/csa/ccm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-csa-ccm",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Cloud Controls Matrix ",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cz/act_101/build.gradle.kts
+++ b/package/cz/act_101/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cz/act_101/gate-stamp.json
+++ b/package/cz/act_101/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cz/act_101/package.json
+++ b/package/cz/act_101/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-cz-act_101",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for cz-act_101",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/ai/build.gradle.kts
+++ b/package/eu/ai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/ai/gate-stamp.json
+++ b/package/eu/ai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/ai/package.json
+++ b/package/eu/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-eu-ai",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package EU Artificial Intelligence (AI)I Act (Regulation (EU) 2024/1689) for vendor EU.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/fr/act_78_17/build.gradle.kts
+++ b/package/fr/act_78_17/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fr/act_78_17/gate-stamp.json
+++ b/package/fr/act_78_17/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fr/act_78_17/package.json
+++ b/package/fr/act_78_17/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-fr-act_78_17",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for fr-act_78_17",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/gb/mds/build.gradle.kts
+++ b/package/gb/mds/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gb/mds/gate-stamp.json
+++ b/package/gb/mds/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gb/mds/package.json
+++ b/package/gb/mds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-gb-mds",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Ministry of Defence Standard 05-138 (14 May 2024) for vendor United Kingdom.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/hu/isdfi/build.gradle.kts
+++ b/package/hu/isdfi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hu/isdfi/gate-stamp.json
+++ b/package/hu/isdfi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hu/isdfi/package.json
+++ b/package/hu/isdfi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-hu-isdfi",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for hu-isdfi",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iec/sae/build.gradle.kts
+++ b/package/iec/sae/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iec/sae/gate-stamp.json
+++ b/package/iec/sae/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iec/sae/package.json
+++ b/package/iec/sae/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-iec-sae",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for iec-sae",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/il/popl/build.gradle.kts
+++ b/package/il/popl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/il/popl/gate-stamp.json
+++ b/package/il/popl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/il/popl/package.json
+++ b/package/il/popl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-il-popl",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for il-popl",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/lu/pp_rppd/build.gradle.kts
+++ b/package/lu/pp_rppd/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/lu/pp_rppd/gate-stamp.json
+++ b/package/lu/pp_rppd/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/lu/pp_rppd/package.json
+++ b/package/lu/pp_rppd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-lu-pp_rppd",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for lu-pp_rppd",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/ai_600/build.gradle.kts
+++ b/package/nist/ai_600/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/ai_600/gate-stamp.json
+++ b/package/nist/ai_600/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/ai_600/package.json
+++ b/package/nist/ai_600/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-nist-ai_600",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package NIST AI 600-1 (AI RMF Generative Artificial Intelligence Profile) for vendor NIST.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/nist/rmf/build.gradle.kts
+++ b/package/nist/rmf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/rmf/gate-stamp.json
+++ b/package/nist/rmf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.4-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/rmf/package.json
+++ b/package/nist/rmf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-nist-rmf",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "suite package for nist-rmf",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/owasp/asvs/build.gradle.kts
+++ b/package/owasp/asvs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/owasp/asvs/gate-stamp.json
+++ b/package/owasp/asvs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/owasp/asvs/package.json
+++ b/package/owasp/asvs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-owasp-asvs",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Application Security Verification Standard",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/owasp/community/build.gradle.kts
+++ b/package/owasp/community/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/owasp/community/gate-stamp.json
+++ b/package/owasp/community/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/owasp/community/package.json
+++ b/package/owasp/community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-owasp-community",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "OWASP Community Pages are a place where OWASP can accept community contributions for security-related content.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/owasp/pc/build.gradle.kts
+++ b/package/owasp/pc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/owasp/pc/gate-stamp.json
+++ b/package/owasp/pc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/owasp/pc/package.json
+++ b/package/owasp/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-owasp-pc",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Provides a solid foundation of topics to help drive introductory software security developer training",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/owasp/wstg/build.gradle.kts
+++ b/package/owasp/wstg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/owasp/wstg/gate-stamp.json
+++ b/package/owasp/wstg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/owasp/wstg/package.json
+++ b/package/owasp/wstg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-owasp-wstg",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Web Security Testing Guide",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pci_ssc/dss/build.gradle.kts
+++ b/package/pci_ssc/dss/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pci_ssc/dss/gate-stamp.json
+++ b/package/pci_ssc/dss/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pci_ssc/dss/package.json
+++ b/package/pci_ssc/dss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-pci_ssc-dss",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for pci_ssc-dss",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pl/act_appd/build.gradle.kts
+++ b/package/pl/act_appd/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pl/act_appd/gate-stamp.json
+++ b/package/pl/act_appd/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pl/act_appd/package.json
+++ b/package/pl/act_appd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-pl-act_appd",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for pl-act_appd",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sa/cscc/build.gradle.kts
+++ b/package/sa/cscc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/cscc/gate-stamp.json
+++ b/package/sa/cscc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/cscc/package.json
+++ b/package/sa/cscc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sa-cscc",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for sa-cscc",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sa/otcc/build.gradle.kts
+++ b/package/sa/otcc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/otcc/gate-stamp.json
+++ b/package/sa/otcc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/otcc/package.json
+++ b/package/sa/otcc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sa-otcc",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for sa-otcc",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sa/pdpl/build.gradle.kts
+++ b/package/sa/pdpl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/pdpl/gate-stamp.json
+++ b/package/sa/pdpl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/pdpl/package.json
+++ b/package/sa/pdpl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sa-pdpl",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Personal Data Protection Law (PDPL) for vendor Saudi Arabia.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/sa/sai/build.gradle.kts
+++ b/package/sa/sai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/sai/gate-stamp.json
+++ b/package/sa/sai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/sai/package.json
+++ b/package/sa/sai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sa-sai",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Saudi Arabia IoT CGIoT-1:2024 for vendor Saudi Arabia.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/sei/cert/build.gradle.kts
+++ b/package/sei/cert/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sei/cert/gate-stamp.json
+++ b/package/sei/cert/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sei/cert/package.json
+++ b/package/sei/cert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sei-cert",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "SEI CERT Coding Standards",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/shared_assessments/sig/build.gradle.kts
+++ b/package/shared_assessments/sig/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/shared_assessments/sig/gate-stamp.json
+++ b/package/shared_assessments/sig/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/shared_assessments/sig/package.json
+++ b/package/shared_assessments/sig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-shared_assessments-sig",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for shared_assessments-sig",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/slsa/slsa/build.gradle.kts
+++ b/package/slsa/slsa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/slsa/slsa/gate-stamp.json
+++ b/package/slsa/slsa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/slsa/slsa/package.json
+++ b/package/slsa/slsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-slsa-slsa",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sparta/counter/build.gradle.kts
+++ b/package/sparta/counter/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sparta/counter/gate-stamp.json
+++ b/package/sparta/counter/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sparta/counter/package.json
+++ b/package/sparta/counter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-sparta-counter",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for sparta-counter",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/tr/rppdecs/build.gradle.kts
+++ b/package/tr/rppdecs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tr/rppdecs/gate-stamp.json
+++ b/package/tr/rppdecs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tr/rppdecs/package.json
+++ b/package/tr/rppdecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-tr-rppdecs",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for tr-rppdecs",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/uae/niaf/build.gradle.kts
+++ b/package/uae/niaf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uae/niaf/gate-stamp.json
+++ b/package/uae/niaf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uae/niaf/package.json
+++ b/package/uae/niaf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-uae-niaf",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package UAE National Information Assurance Framework (NIAF) for vendor UAE.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us/cjis/build.gradle.kts
+++ b/package/us/cjis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/cjis/gate-stamp.json
+++ b/package/us/cjis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/cjis/package.json
+++ b/package/us/cjis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-cjis",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us-cjis",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/facta/build.gradle.kts
+++ b/package/us/facta/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/facta/gate-stamp.json
+++ b/package/us/facta/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/facta/package.json
+++ b/package/us/facta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-facta",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us-facta",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/fca/build.gradle.kts
+++ b/package/us/fca/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/fca/gate-stamp.json
+++ b/package/us/fca/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/fca/package.json
+++ b/package/us/fca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-fca",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Farm Credit Administration (FCA) Cyber Risk Management for vendor United States.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us/framp/build.gradle.kts
+++ b/package/us/framp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/framp/gate-stamp.json
+++ b/package/us/framp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/framp/package.json
+++ b/package/us/framp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-framp",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us-framp",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/hicp/build.gradle.kts
+++ b/package/us/hicp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/hicp/gate-stamp.json
+++ b/package/us/hicp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/hicp/package.json
+++ b/package/us/hicp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-hicp",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Health Industry Cybersecurity Practices (HICP) for vendor United States.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us/hipaa/build.gradle.kts
+++ b/package/us/hipaa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/hipaa/gate-stamp.json
+++ b/package/us/hipaa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/hipaa/package.json
+++ b/package/us/hipaa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-hipaa",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package Health Insurance Portability and Accountability Act (HIPAA) for vendor United States.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us/nispom/build.gradle.kts
+++ b/package/us/nispom/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/nispom/gate-stamp.json
+++ b/package/us/nispom/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/nispom/package.json
+++ b/package/us/nispom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-nispom",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us-nispom",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/ssa/build.gradle.kts
+++ b/package/us/ssa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/ssa/gate-stamp.json
+++ b/package/us/ssa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/ssa/package.json
+++ b/package/us/ssa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us-ssa",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us-ssa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ak/pipa/build.gradle.kts
+++ b/package/us_ak/pipa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ak/pipa/gate-stamp.json
+++ b/package/us_ak/pipa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ak/pipa/package.json
+++ b/package/us_ak/pipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_ak-pipa",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us_ak-pipa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ca/cpra/build.gradle.kts
+++ b/package/us_ca/cpra/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ca/cpra/gate-stamp.json
+++ b/package/us_ca/cpra/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ca/cpra/package.json
+++ b/package/us_ca/cpra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_ca-cpra",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us_ca-cpra",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_il/bipa/build.gradle.kts
+++ b/package/us_il/bipa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_il/bipa/gate-stamp.json
+++ b/package/us_il/bipa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_il/bipa/package.json
+++ b/package/us_il/bipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_il-bipa",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us_il-bipa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_or/cpa/build.gradle.kts
+++ b/package/us_or/cpa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_or/cpa/gate-stamp.json
+++ b/package/us_or/cpa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.1.1-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_or/cpa/package.json
+++ b/package/us_or/cpa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_or-cpa",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Suite package OR - Consumer Privacy Act (SB 619) for vendor Oregon.",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us_tx/dir_scc/build.gradle.kts
+++ b/package/us_tx/dir_scc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tx/dir_scc/gate-stamp.json
+++ b/package/us_tx/dir_scc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tx/dir_scc/package.json
+++ b/package/us_tx/dir_scc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_tx-dir_scc",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us_tx-dir_scc",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_tx/tx_ramp/build.gradle.kts
+++ b/package/us_tx/tx_ramp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tx/tx_ramp/gate-stamp.json
+++ b/package/us_tx/tx_ramp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tx/tx_ramp/package.json
+++ b/package/us_tx/tx_ramp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-us_tx-tx_ramp",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for us_tx-tx_ramp",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/uy/law/build.gradle.kts
+++ b/package/uy/law/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uy/law/gate-stamp.json
+++ b/package/uy/law/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uy/law/package.json
+++ b/package/uy/law/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-uy-law",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "suite package for uy-law",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/whitehouse/memo/build.gradle.kts
+++ b/package/whitehouse/memo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/whitehouse/memo/gate-stamp.json
+++ b/package/whitehouse/memo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.3-uat.0",
+  "branch": "feat/migrate-suites-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/whitehouse/memo/package.json
+++ b/package/whitehouse/memo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-whitehouse-memo",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Presidential Memoranda",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

50 suites migrated cleanly to the gradle (`zb.content`) pipeline. One commit per suite. No drift fixes needed.

Migrated set: `il/popl`, `csa/ccm`, `sa/sai`, `owasp/wstg`, `us_il/bipa`, `pl/act_appd`, `us_or/cpa`, `us_tx/dir_scc`, `us_ak/pipa`, `au/ism`, `sa/otcc`, `us/framp`, `us_ca/cpra`, `cisa/ssdaf`, `us/hicp`, `nist/ai_600`, `pci_ssc/dss`, `iec/sae`, `cz/act_101`, `nist/rmf`, `sa/pdpl`, `whitehouse/memo`, `owasp/asvs`, `us/nispom`, `sei/cert`, `uae/niaf`, `sparta/counter`, `sa/cscc`, `eu/ai`, `us/hipaa`, `us_tx/tx_ramp`, `ca/pipeda`, `fr/act_78_17`, `uy/law`, `at/dsg`, `gb/mds`, `tr/rppdecs`, `slsa/slsa`, `cn/pipl`, `shared_assessments/sig`, `lu/pp_rppd`, `hu/isdfi`, `us/fca`, `us/cjis`, `us/facta`, `owasp/pc`, `au/cp_sitc`, `bm/bmaccc`, `owasp/community`, `us/ssa`.

After merge: **158 / 287 (55.0%)** migrated.

## Test plan
- [ ] `detect` matrix lists exactly these 50 suites
- [ ] `testIntegrationDataloader` per-suite against Neon
- [ ] `refresh-bundle` updates `bundle/package.json`
- [ ] `sync` propagates main → uat → qa → dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)