### PR TITLE
fix(suite): restore logo.* glob in package.json files for 10 over-tidied suites

### DIFF
--- a/package/microsoft/azure/package.json
+++ b/package/microsoft/azure/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-microsoft": "latest"

--- a/package/nist/800-171/package.json
+++ b/package/nist/800-171/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/800-218/package.json
+++ b/package/nist/800-218/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/800-53/package.json
+++ b/package/nist/800-53/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/800_218/package.json
+++ b/package/nist/800_218/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/800_53a/package.json
+++ b/package/nist/800_53a/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/800_53b/package.json
+++ b/package/nist/800_53b/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/fips/package.json
+++ b/package/nist/fips/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/ir8397/package.json
+++ b/package/nist/ir8397/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"

--- a/package/nist/sp/package.json
+++ b/package/nist/sp/package.json
@@ -14,7 +14,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "files": [
-    "index.yml"
+    "index.yml",
+    "logo.*"
   ],
   "dependencies": {
     "@zerobias-org/vendor-nist": "latest"


### PR DESCRIPTION
## Summary

During the gradle migration, 10 NIST/microsoft suites had their broken placeholder logos (472B / 203B SVGs, below the validator's 500B floor) removed from disk. The same change also stripped `"logo.*"` from the `files` array in each `package.json` — which was over-eager. The validator's `validateLogo` in `build.gradle.kts` early-returns when no logo file is present; it never inspects the `files` array in that path. Removing the glob accomplished nothing the validator wanted, but it:

- diverged 10 suites from the canonical shape (`templates/package.json` and 277 other suites all keep `"logo.*"`)
- made future logo restoration require editing `package.json` too, not just dropping an asset

This PR puts `"logo.*"` back in `files` for those 10 suites. The actual logo files are still absent on disk — that's a separate question (whether to source proper higher-resolution logos vs. lower the validator floor). This change is a pure shape-fix.

## Affected suites

`microsoft/azure`, `nist/sp`, `nist/fips`, `nist/800_53a`, `nist/800_53b`, `nist/800_218`, `nist/ir8397`, `nist/800-53`, `nist/800-171`, `nist/800-218`

## Publish behaviour

`detect` diffs `build.gradle.kts` markers — none changed here, so the matrix should be empty and no republishes fire. The fix lands on main and applies on the next real publish of each suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)