### PR TITLE
chore(suite-hci-mediacare)!: deprecate redundant MediaCare suite

### DIFF
--- a/package/hci/mediacare/gate-stamp.json
+++ b/package/hci/mediacare/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0-uat.0",
-  "branch": "feat/hci-mediacare-suite",
+  "version": "2.0.0-uat.0",
+  "branch": "fix/deprecate-hci-mediacare-suite",
   "sourceHash": "f897291e74be64ddfe9b5bb6b8a1ea830df98ab6f396e7549865b08a3db9e93b",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/hci/mediacare/package.json
+++ b/package/hci/mediacare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/suite-hci-mediacare",
-  "version": "1.0.0-rc.1",
+  "version": "2.0.0",
   "description": "MediaCare",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -23,6 +23,7 @@
   "zerobias": {
     "dataloader-version": "1.0.0",
     "import-artifact": "suite",
-    "package": "hci.mediacare"
+    "package": "hci.mediacare",
+    "deprecated": true
   }
 }


### PR DESCRIPTION
Deprecates `@zerobias-org/suite-hci-mediacare` (1.0.0 → **2.0.0**, `zerobias.deprecated: true`).

Per the VSP rule (a suite only earns its place when it groups 2+ distinct products), MediaCare is a single **vendor-parented product** (`hci.mediacare`), not a suite. This retires the redundant `x.x` suite.

On load, the dataloader takes the deprecation path — `suiteDao.delete()` + `packageDao.deleteByPackageCode('hci.mediacare')` — which removes the suite record and **frees the `hci.mediacare` package code** for the new vendor-parented product (`catalog.package.package_code` is globally UNIQUE, so the code must be freed first).

Gate green (dataloader ran the deprecation delete path). Dir kept for now; will be removed in a follow-up per repo policy.

Paired with the product-side changes: deprecate `product-hci-mediacare-mediacare` + add vendor-parented `product-hci-mediacare`.