### PR TITLE
fix(cyberab-sca): regenerate gate stamp after files are git-tracked

### DIFF
--- a/package/cyberab/sca/gate-stamp.json
+++ b/package/cyberab/sca/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-uat.0",
-  "branch": "feat/suite-cyberab-sca",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "fix/sca-gate-stamp",
+  "sourceHash": "a262c4462a8ae6cb171e70b62ecb05e6e94aa131c5b05d68fbd166e4494d913d",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",


### PR DESCRIPTION
Publish run 31402804952 failed at preflight (`source-hash-changed`). Root cause (confirmed in build-tools `zb.base.gradle.kts`): SourceHasher hashes via `git ls-files`, tracked files only — the stamp in #51 was generated before `git add`, so it covered an incomplete file set. Regenerated with everything tracked; gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)